### PR TITLE
Fixed FSDP compile for RoPE 

### DIFF
--- a/llama.py
+++ b/llama.py
@@ -205,7 +205,7 @@ def precompute_freq_cis(dim, rope_base, max_seq_len, **kwargs):
     pos_idx_T = torch.arange(max_seq_len)
     freq_TF = pos_idx_T.unsqueeze(1) * theta_F.unsqueeze(0)
     freq_cis_TF = torch.polar(torch.ones_like(freq_TF), freq_TF)
-    freq_cis_TFC = torch.view_as_real(freq_cis_TF)
+    freq_cis_TFC = torch.stack([freq_cis_TF.real, freq_cis_TF.imag], dim=-1)
     return freq_cis_TFC
 
 


### PR DESCRIPTION
Fixed this RoPE error when compiling LLaMA models:
```
assert a == b, f"{a} != {b}"
AssertionError: torch.complex64 != torch.bfloat16

from user code:
   File "/workspace/llm-train-bench/llama.py", line 188, in forward
    x_BTE = tsfmr_blk(x_BTE, self.freq_cis_TFC)
```

- Replaced `torch.view_as_complex`: This triggers the error even with explicit data type casting
- Removed all gradient scalers and migrated to BFloat16

Experiments: For `llama-2-7b-proxy` at `bsz=32` and `pt-compile=True`, we reach ~55% MFU.