### PR TITLE
Initial amd

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ To start the container:
 ```bash
 ./docker/launch.sh
 ```
+### AMD
+To build the image:
+```bash
+docker build -t llm-train-bench -f ./docker/Dockerfile.amd .
+```
+
+To start the container:
+```bash
+./docker/launch_amd.sh
+```
+
+##### IMPORTANT for amd
+set env flag `DISABLE_ADDMM_HIP_LT=0`
 
 
 ## Single GPU Training

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -1,0 +1,15 @@
+FROM rocm/pytorch:latest-internal
+
+RUN apt install nano
+
+# RUN pip3 uninstall -y torch
+
+# RUN pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+
+RUN pip install uv
+
+RUN uv pip install --system ipython pytest fire pydantic
+
+WORKDIR /workspace/llm-train-bench/
+
+CMD ["/usr/bin/bash"]

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -1,10 +1,11 @@
-FROM rocm/pytorch:latest-internal
+FROM rocm/pytorch:rocm6.2_ubuntu22.04_py3.10_pytorch_release_2.3.0
+# FROM rocm/pytorch:latest-internal
 
 RUN apt install nano
 
-# RUN pip3 uninstall -y torch
+RUN pip3 uninstall -y torch
 
-# RUN pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+RUN pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.2
 
 RUN pip install uv
 

--- a/docker/launch_amd.sh
+++ b/docker/launch_amd.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CMD=$1
+IT_FLAG=${1:+-t}
+
+sudo docker run --privileged --network=host --device=/dev/kfd --device=/dev/dri --group-add video \
+    --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --ipc=host --shm-size 192G \
+    --rm ${IT_FLAG:=-it} \
+    -v .:/workspace/llm-train-bench/ \
+    llm-train-bench $CMD

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -134,7 +134,7 @@ def train(
 
                     t = start.elapsed_time(end) / 1e3
                     flops_per_sec = flops_per_iter / t
-                    mfu = flops_per_sec / 989.5e12
+                    mfu = flops_per_sec / flops_promised
 
                     pbar.set_description(f'[Rank {rank}]  {(flops_per_sec/1e12):.2f} TFLOP/s  MFU={mfu:.2%}')
                 else:

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -50,13 +50,12 @@ def train(
 
     with open(cfg_path) as f:
         cfg_json = json.load(f)
-    match cfg_json['arch_name']:
-        case 'gpt':
+    if cfg_json['arch_name'] == 'gpt':
             cfg_cls, model_cls = GPTConfig, GPT
-        case 'llama':
+    elif cfg_json['arch_name'] == 'llama':
             cfg_cls, model_cls = LLaMAConfig, LLaMA
-        case _:
-            raise ValueError(f'Model architecture {cfg_json["arch_name"]} not supported.')
+    else:
+        raise ValueError(f'Model architecture {cfg_json["arch_name"]} not supported.')
     cfg_m = cfg_cls(**cfg_json)
     model = DDP(model_cls(**cfg_json).to(rank))
     if pt_compile:


### PR DESCRIPTION
Inital AMD stuff


around 330TFLOPs for the below command. only eager mode works on pypi nightly. compile mode `rocm/pytorch:latest-internal` but at like 100 TFLOPs

```bash
DISABLE_ADDMM_HIP_LT=0 python ./train_ddp.py ./configs/llama-2-7b-proxy.json --bsz=64
```